### PR TITLE
本番デプロイ用の Dockerfile の作成

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+/vendor
+/docker
+/log
+/spec
+/storage
+/tmp
+/docker-compose.yml
+/.*
+/alias.sh
+/start_dev_server.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# こちらを参考にした
+# https://github.com/GoogleCloudPlatform/ruby-docs-samples/blob/5a0fce7f41412b0b3b208f9d3b51fdf7ad6bf1f2/run/rails/Dockerfile
+
+# ToDo: いずれ軽量化も検討したい
+
+FROM ruby:3.2.0-buster
+
+WORKDIR /app
+
+# Application dependencies
+COPY Gemfile Gemfile.lock ./
+RUN gem install bundler && \
+    bundle config set --local deployment 'true' && \
+    bundle config set --local without 'development test' && \
+    bundle install
+
+# Copy application code to the container image
+COPY . /app
+
+# production, staging などビルド引数で指定する
+ARG ENV
+ENV RAILS_ENV=${ENV}
+# Redirect Rails log to STDOUT for Cloud Run to capture
+ENV RAILS_LOG_TO_STDOUT=true
+
+EXPOSE 8080
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "8080"]


### PR DESCRIPTION
closes #8 

とりあえず一度デプロイをしてみるための Dockerfile と .dockerignore を作成。  
可能であれば将来的にはイメージの軽量化もしたい。  
現状ではビルドしたイメージは 950MB で、Artifact Registry の無料枠を1回で超えるサイズになっている。

デプロイ用 Dockerfile に関する [wiki](https://github.com/commew/timelogger-api/wiki/%E3%83%87%E3%83%97%E3%83%AD%E3%82%A4%E7%94%A8-Dockerfile-%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6) も追加。  
そちらに参考にした情報 (Cloud Run 公式) のリンクも添えている。

@HAYASHI-Masayuki 
お手すきの際にレビューをお願いできますでしょうか？
よろしくお願いいたします。