### PR TITLE
機密情報管理用の鍵ファイルをコンテナイメージの build context から除外

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,5 @@
 /.*
 /alias.sh
 /start_dev_server.sh
+/.github
+/config/credentials/*.key


### PR DESCRIPTION
## 関連する issue のコメント

https://github.com/commew/timelogger-api/issues/23#issuecomment-1574730783

## 内容

自動デプロイでは git 管理下のファイルだけがコンテナイメージの build context になっている。

しかしもしローカルからデプロイを行う必要があった場合に、機密情報の鍵ファイルがコンテナイメージに含まれてしまう可能性があった。
ローカル環境では機密情報を編集・参照する目的で鍵ファイルを設置している可能性が高く、明示的に build context から除外するよう、
.gitignore の編集を行った。

ついでに、最近追加した .github/ もイメージ内に不要なので除外した。

## レビュワーの方へ

おつかれさまです！
小さな変更ですが、ご確認をお願いできればと思います！