### PR TITLE
タスクグループを取得する API の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'bootsnap', require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 6.0.0'
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,11 @@ GEM
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     erubi (1.12.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -208,6 +213,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  factory_bot_rails
   mysql2 (~> 0.5)
   puma (~> 5.0)
   rails (~> 7.0.4)

--- a/app/controllers/task_groups_controller.rb
+++ b/app/controllers/task_groups_controller.rb
@@ -1,2 +1,16 @@
 class TaskGroupsController < ApplicationController
+  def index
+    render_list
+  end
+
+  private
+
+  def render_list
+    ## 仮のデータ用意
+    ## 本来は account に紐づく TaskGroup の配列を取得する
+    task_group = (TaskGroup.first.presence || TaskGroup.create(name: '仕事'))
+    render json: {
+      groups: [task_group.as_json]
+    }
+  end
 end

--- a/app/controllers/task_groups_controller.rb
+++ b/app/controllers/task_groups_controller.rb
@@ -1,0 +1,2 @@
+class TaskGroupsController < ApplicationController
+end

--- a/app/controllers/task_groups_controller.rb
+++ b/app/controllers/task_groups_controller.rb
@@ -7,10 +7,10 @@ class TaskGroupsController < ApplicationController
 
   def render_list
     ## 仮のデータ用意
-    ## 本来は account に紐づく TaskGroup の配列を取得する
-    task_group = (TaskGroup.first.presence || TaskGroup.create(name: '仕事'))
+    ## 本来はリクエストをした account に紐づく TaskGroup の配列を取得する
+    account = Account.first || FactoryBot.create(:account)
     render json: {
-      groups: [task_group.as_json]
+      groups: account.task_groups.as_json
     }
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,12 +1,19 @@
 class Account < ApplicationRecord
   has_many :open_id_providers, dependent: :destroy
+  has_many :task_groups, dependent: :destroy
 
   validates :open_id_providers, presence: true
+
+  after_create :create_task_groups
 
   def self.create_with_open_id_provider(sub, provider)
     new.tap do |account|
       account.open_id_providers.new(sub:, provider:)
       account.save
     end
+  end
+
+  def create_task_groups
+    task_groups << TaskGroup.default_tasks
   end
 end

--- a/app/models/task_category.rb
+++ b/app/models/task_category.rb
@@ -1,0 +1,2 @@
+class TaskCategory < ApplicationRecord
+end

--- a/app/models/task_category.rb
+++ b/app/models/task_category.rb
@@ -1,2 +1,3 @@
 class TaskCategory < ApplicationRecord
+  belongs_to :task_group, dependent: :destroy
 end

--- a/app/models/task_category.rb
+++ b/app/models/task_category.rb
@@ -1,3 +1,7 @@
 class TaskCategory < ApplicationRecord
   belongs_to :task_group
+
+  def as_json
+    super(only: %i[id name])
+  end
 end

--- a/app/models/task_category.rb
+++ b/app/models/task_category.rb
@@ -1,3 +1,3 @@
 class TaskCategory < ApplicationRecord
-  belongs_to :task_group, dependent: :destroy
+  belongs_to :task_group
 end

--- a/app/models/task_group.rb
+++ b/app/models/task_group.rb
@@ -32,15 +32,24 @@ class TaskGroup < ApplicationRecord
   ## account table は別 issue で対応のため、今はコメントアウト
   # belongs_to :account
   # validates :account, presence: true
-  has_many :task_categories, dependent: :destroy
+
+  # API の返り値のキーが categories なのでそれに合わせる
+  has_many :categories, class_name: :TaskCategory, dependent: :destroy
 
   after_create :create_categories
+
+  def as_json
+    super(only: %i[id name],
+          include: [
+            { categories: { only: %i[id name] } }
+          ])
+  end
 
   private
 
   def create_categories
     INIT_DATA[name].each do |category|
-      task_categories.create(category)
+      categories.create(category)
     end
   end
 end

--- a/app/models/task_group.rb
+++ b/app/models/task_group.rb
@@ -1,2 +1,46 @@
 class TaskGroup < ApplicationRecord
+  # 仮りで初期生成される task_group と task_categories
+  INIT_DATA = {
+    '仕事' => [
+      {
+        name: '会議'
+      },
+      {
+        name: '資料作成'
+      }
+    ],
+    '学習' => [
+      {
+        name: 'TOEIC'
+      }
+    ],
+    '趣味' => [
+      {
+        name: '散歩'
+      },
+      {
+        name: '読書'
+      }
+    ],
+    'グループ未分類' => [
+      {
+        name: '移動・外出'
+      }
+    ]
+  }.freeze
+
+  ## account table は別 issue で対応のため、今はコメントアウト
+  # belongs_to :account
+  # validates :account, presence: true
+  has_many :task_categories, dependent: :destroy
+
+  after_create :create_categories
+
+  private
+
+  def create_categories
+    INIT_DATA[name].each do |category|
+      task_categories.create(category)
+    end
+  end
 end

--- a/app/models/task_group.rb
+++ b/app/models/task_group.rb
@@ -1,0 +1,2 @@
+class TaskGroup < ApplicationRecord
+end

--- a/app/models/task_group.rb
+++ b/app/models/task_group.rb
@@ -45,6 +45,14 @@ class TaskGroup < ApplicationRecord
           ])
   end
 
+  class << self
+    def create_default_tasks(_account)
+      INIT_DATA.each_key do |task_group_name|
+        create(name: task_group_name)
+      end
+    end
+  end
+
   private
 
   def create_categories

--- a/app/models/task_group.rb
+++ b/app/models/task_group.rb
@@ -29,9 +29,7 @@ class TaskGroup < ApplicationRecord
     ]
   }.freeze
 
-  ## account table は別 issue で対応のため、今はコメントアウト
-  # belongs_to :account
-  # validates :account, presence: true
+  belongs_to :account
 
   # API の返り値のキーが categories なのでそれに合わせる
   has_many :categories, class_name: :TaskCategory, dependent: :destroy
@@ -46,9 +44,9 @@ class TaskGroup < ApplicationRecord
   end
 
   class << self
-    def create_default_tasks(_account)
-      INIT_DATA.each_key do |task_group_name|
-        create(name: task_group_name)
+    def default_tasks
+      INIT_DATA.each_key.map do |task_group_name|
+        TaskGroup.new(name: task_group_name)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   resources :accounts, only: [:create]
-
+  resources :task_groups, only: [:index], path: "task-groups"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/db/migrate/20230722093833_create_task_groups.rb
+++ b/db/migrate/20230722093833_create_task_groups.rb
@@ -1,0 +1,8 @@
+class CreateTaskGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :task_groups do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230722093833_create_task_groups.rb
+++ b/db/migrate/20230722093833_create_task_groups.rb
@@ -1,7 +1,8 @@
 class CreateTaskGroups < ActiveRecord::Migration[7.0]
   def change
     create_table :task_groups do |t|
-
+      t.references :account, null: false
+      t.string :name, null: false, default: ''
       t.timestamps
     end
   end

--- a/db/migrate/20230722093833_create_task_groups.rb
+++ b/db/migrate/20230722093833_create_task_groups.rb
@@ -1,7 +1,8 @@
 class CreateTaskGroups < ActiveRecord::Migration[7.0]
   def change
     create_table :task_groups do |t|
-      t.references :account, null: false
+      # accounts table は別 issue の範囲なので一旦コメントアウト対応
+      # t.references :account, null: false
       t.string :name, null: false, default: ''
       t.timestamps
     end

--- a/db/migrate/20230722093946_create_task_categories.rb
+++ b/db/migrate/20230722093946_create_task_categories.rb
@@ -1,7 +1,8 @@
 class CreateTaskCategories < ActiveRecord::Migration[7.0]
   def change
     create_table :task_categories do |t|
-
+      t.references :task_group, null: false
+      t.string :name, null: false, default: ''
       t.timestamps
     end
   end

--- a/db/migrate/20230722093946_create_task_categories.rb
+++ b/db/migrate/20230722093946_create_task_categories.rb
@@ -1,0 +1,8 @@
+class CreateTaskCategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :task_categories do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230730063102_add_reference_account_to_task_groups.rb
+++ b/db/migrate/20230730063102_add_reference_account_to_task_groups.rb
@@ -1,0 +1,7 @@
+class AddReferenceAccountToTaskGroups < ActiveRecord::Migration[7.0]
+  def change
+    change_table :task_groups do |t|
+      t.references :account, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_24_103949) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_30_063102) do
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -26,5 +26,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_103949) do
     t.index ["sub", "provider"], name: "index_open_id_providers_on_sub_and_provider", unique: true
   end
 
-  add_foreign_key "open_id_providers", "accounts"
+  create_table "task_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "task_group_id", null: false
+    t.string "name", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_group_id"], name: "index_task_categories_on_task_group_id"
+  end
+
+  create_table "task_groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "account_id", null: false
+    t.index ["account_id"], name: "index_task_groups_on_account_id"
+  end
+
 end

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :account do
+    open_id_providers { [FactoryBot.build(:open_id_provider)] }
+
+    # Account は create されると TaskGroups も自動で作られる
+    # TaskGroup 側のテストで困ることがあるので、
+    # callback を一時的に skip した状態で Account を作成することもできるようにする
+    transient do
+      skip_callback { false }
+    end
+
+    after(:build) do |account, evaluator|
+      account.class.skip_callback(:create, :after, :create_task_groups) if evaluator.skip_callback
+    end
+
+    after(:create) do |account, evaluator|
+      account.class.set_callback(:create, :after, :create_task_groups) if evaluator.skip_callback
+    end
+  end
+end

--- a/spec/factories/open_id_providers.rb
+++ b/spec/factories/open_id_providers.rb
@@ -1,0 +1,8 @@
+# 呼ぶときは FactoryBot.build :open_id_provider とすること (インスタンス生成だけ)
+# Account との関連なしに DB 保存しようとするとエラーが発生する
+FactoryBot.define do
+  factory :open_id_provider do
+    sub { '111111111111111111111' }
+    provider { 'google' }
+  end
+end

--- a/spec/factories/task_categories.rb
+++ b/spec/factories/task_categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :task_category do
+    name { '会議' }
+  end
+end

--- a/spec/factories/task_groups.rb
+++ b/spec/factories/task_groups.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :task_group do
+    ## 現状では TaskGropu の name の取りうる値は固定となっている
+    ## また、その name に併せて TaskCategor が自動生成されるようになっている
+    ## そのためここではハードコードしているのが、必要になったら改修が必要
+    name { '仕事' }
+  end
+end

--- a/spec/factories/task_groups.rb
+++ b/spec/factories/task_groups.rb
@@ -1,8 +1,6 @@
 FactoryBot.define do
   factory :task_group do
-    ## 現状では TaskGropu の name の取りうる値は固定となっている
-    ## また、その name に併せて TaskCategor が自動生成されるようになっている
-    ## そのためここではハードコードしているのが、必要になったら改修が必要
     name { '仕事' }
+    account { association :account, skip_callback: true }
   end
 end

--- a/spec/models/task_category_spec.rb
+++ b/spec/models/task_category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TaskCategory do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/task_category_spec.rb
+++ b/spec/models/task_category_spec.rb
@@ -1,4 +1,1 @@
 require 'rails_helper'
-
-RSpec.describe TaskCategory do
-end

--- a/spec/models/task_category_spec.rb
+++ b/spec/models/task_category_spec.rb
@@ -1,12 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe TaskCategory do
-  context 'when related task_group was deleted' do
-    let(:sample_task_name) { TaskGroup::INIT_DATA.keys.first }
-    let(:task_group) { TaskGroup.create(name: sample_task_name).delete }
-
-    it 'related task_categories should be deleted as if cascading.' do
-      expect(described_class.count).to eq(0)
-    end
-  end
 end

--- a/spec/models/task_category_spec.rb
+++ b/spec/models/task_category_spec.rb
@@ -1,5 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe TaskCategory do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'when related task_group was deleted' do
+    let(:sample_task_name) { TaskGroup::INIT_DATA.keys.first }
+    let(:task_group) { TaskGroup.create(name: sample_task_name).delete }
+
+    it 'related task_categories should be deleted as if cascading.' do
+      expect(described_class.count).to eq(0)
+    end
+  end
 end

--- a/spec/models/task_group_spec.rb
+++ b/spec/models/task_group_spec.rb
@@ -12,11 +12,18 @@ RSpec.describe TaskGroup do
     end
   end
 
-  context 'when task_group was deleted' do
+  describe 'when task_group was deleted' do
     let(:task_group) { create(:task_group).destroy }
 
     it 'related task_categories should be deleted as if cascading.' do
       expect(TaskCategory.count).to eq(0)
+    end
+  end
+
+  describe '.create_default_tasks' do
+    it 'default task_groups was created.' do
+      described_class.create_default_tasks 'account_will_be_passed'
+      expect(described_class.count).to eq(described_class::INIT_DATA.length)
     end
   end
 end

--- a/spec/models/task_group_spec.rb
+++ b/spec/models/task_group_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TaskGroup do
       let(:task_group) { create(:task_group) }
 
       it 'affect to create task_categories.' do
-        expect(task_group.task_categories.count).not_to eq(0)
+        expect(task_group.categories.count).not_to eq(0)
       end
     end
   end

--- a/spec/models/task_group_spec.rb
+++ b/spec/models/task_group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TaskGroup do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/task_group_spec.rb
+++ b/spec/models/task_group_spec.rb
@@ -1,5 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe TaskGroup do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # TasdGroup,TaskCategory のデフォルト値が変わる可能性があるため、
+  # テストにハードコードしない目的の記述
+  sample_task_group_name = described_class::INIT_DATA.keys.first
+  sample_task_category_names = described_class::INIT_DATA[sample_task_group_name].pluck(:name)
+
+  # #create_categories is registerd to "after_create"
+  describe '#create_categories' do
+    context "when created task_group's name prop is \"#{sample_task_group_name}\"" do
+      let(:task_group) { described_class.create(name: sample_task_group_name) }
+      let(:task_category_names) do
+        described_class::INIT_DATA[sample_task_group_name].pluck(:name)
+      end
+
+      it 'affect to create task_categories.' do
+        expect(task_group.task_categories.pluck(:name)).to eq(sample_task_category_names)
+      end
+    end
+  end
 end

--- a/spec/models/task_group_spec.rb
+++ b/spec/models/task_group_spec.rb
@@ -19,4 +19,11 @@ RSpec.describe TaskGroup do
       end
     end
   end
+
+  context 'when task_group was deleted' do
+    it 'related task_categories should be deleted as if cascading.' do
+      described_class.create(name: sample_task_group_name).destroy
+      expect(TaskCategory.count).to eq(0)
+    end
+  end
 end

--- a/spec/models/task_group_spec.rb
+++ b/spec/models/task_group_spec.rb
@@ -13,17 +13,23 @@ RSpec.describe TaskGroup do
   end
 
   describe 'when task_group was deleted' do
-    let(:task_group) { create(:task_group).destroy }
-
     it 'related task_categories should be deleted as if cascading.' do
+      create(:task_group).destroy
       expect(TaskCategory.count).to eq(0)
     end
   end
 
-  describe '.create_default_tasks' do
-    it 'default task_groups was created.' do
-      described_class.create_default_tasks 'account_will_be_passed'
-      expect(described_class.count).to eq(described_class::INIT_DATA.length)
+  describe '.default_tasks' do
+    context 'when there are default task instances' do
+      let(:default_tasks) { described_class.default_tasks }
+
+      it 'task names are matched.' do
+        expect(default_tasks.pluck(:name)).to eq(described_class::INIT_DATA.keys)
+      end
+
+      it 'this method don\'t save data, so no categories' do
+        expect(default_tasks.first.categories).to be_empty
+      end
     end
   end
 end

--- a/spec/models/task_group_spec.rb
+++ b/spec/models/task_group_spec.rb
@@ -1,28 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe TaskGroup do
-  # TasdGroup,TaskCategory のデフォルト値が変わる可能性があるため、
-  # テストにハードコードしない目的の記述
-  sample_task_group_name = described_class::INIT_DATA.keys.first
-  sample_task_category_names = described_class::INIT_DATA[sample_task_group_name].pluck(:name)
-
   # #create_categories is registerd to "after_create"
   describe '#create_categories' do
-    context "when created task_group's name prop is \"#{sample_task_group_name}\"" do
-      let(:task_group) { described_class.create(name: sample_task_group_name) }
-      let(:task_category_names) do
-        described_class::INIT_DATA[sample_task_group_name].pluck(:name)
-      end
+    context 'when a task_group created' do
+      let(:task_group) { create(:task_group) }
 
       it 'affect to create task_categories.' do
-        expect(task_group.task_categories.pluck(:name)).to eq(sample_task_category_names)
+        expect(task_group.task_categories.count).not_to eq(0)
       end
     end
   end
 
   context 'when task_group was deleted' do
+    let(:task_group) { create(:task_group).destroy }
+
     it 'related task_categories should be deleted as if cascading.' do
-      described_class.create(name: sample_task_group_name).destroy
       expect(TaskCategory.count).to eq(0)
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require_relative '../config/environment'
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'support/factory_bot'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/requests/task_groups_spec.rb
+++ b/spec/requests/task_groups_spec.rb
@@ -1,7 +1,85 @@
 require 'rails_helper'
 
-RSpec.describe "TaskGroups", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+RSpec.describe 'TaskGroups' do
+  describe 'GET /task-groups' do
+    before do
+      get '/task-groups'
+    end
+
+    it 'response is OK' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'when success, inspect body schema' do
+      ## 現時点での期待されるレスポンスのスキーマ
+      # {
+      #   "groups": [
+      #     {
+      #       "id": 1,
+      #       "name": "仕事",
+      #       "categories": [
+      #         {
+      #           "id": 1,
+      #           "name": "会議"
+      #         },
+      #         {
+      #           "id": 2,
+      #           "name": "資料作成"
+      #         }
+      #       ]
+      #     },
+      #     {
+      #       "id": 2,
+      #       "name": "学習",
+      #       "categories": [
+      #         {
+      #           "id": 3,
+      #           "name": "TOEIC"
+      #         }
+      #       ]
+      #     },
+      #     {
+      #       "id": 3,
+      #       "name": "趣味",
+      #       "categories": [
+      #         {
+      #           "id": 4,
+      #           "name": "散歩"
+      #         },
+      #         {
+      #           "id": 5,
+      #           "name": "読書"
+      #         }
+      #       ]
+      #     },
+      #     {
+      #       "id": 4,
+      #       "name": "グループ未分類",
+      #       "categories": [
+      #         {
+      #           "id": 6,
+      #           "name": "移動・外出"
+      #         }
+      #       ]
+      #     }
+      #   ]
+      # }
+      let(:result) { JSON.parse(response.body) }
+      let(:top_level_keys) { result.keys }
+      let(:categories_keys) { result[top_level_keys.first].first['categories'].first.keys }
+      let(:second_level_keys) { result[top_level_keys.first].first.keys }
+
+      it 'top level keys is ["groups"]' do
+        expect(top_level_keys).to eq(['groups'])
+      end
+
+      it 'second level keys is ["id", "name", "categories"]' do
+        expect(second_level_keys).to eq(%w[id name categories])
+      end
+
+      it 'categories keys is ["id", "name"]' do
+        expect(categories_keys).to eq(%w[id name])
+      end
+    end
   end
 end

--- a/spec/requests/task_groups_spec.rb
+++ b/spec/requests/task_groups_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'TaskGroups' do
     end
 
     it 'response is OK' do
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(200)
     end
 
     context 'when success, inspect body schema' do

--- a/spec/requests/task_groups_spec.rb
+++ b/spec/requests/task_groups_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "TaskGroups", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
close #42

## この PR 対応したこと

- [x] task_groups のテーブル定義
- [x] task_categories のテーブル定義
- [x] TaskGroup モデルにて、自身の生成時に TaskCategory も作成される処理を記述
- [x] TaskCategory にて、親となる TaskGroup の削除時に自動削除されることのテストを記述
- [x] コントローラの定義
- [x] リクエストに含まれるアカウント情報に紐づく TaskGroup を返す処理を記述
(TaskCategory をネストに持つ
- [ ] ~~リクエストに対する例外処理を記述~~ (異常系は別 issue で対応予定)

長いので要するに、 `GET /task-groups` が役に立つ状態になっていること。

## この PR で未対応のもの

- リクエスト元の account の特定
jwt 検証による account の authorization 機能は別 issue での対応範囲となっています。
そのため仮として `Account.first || Account.new` のような処理で account を取り出しています。
それで取れた account をアクセス者として扱い、それに紐づく TaskGroups を
JSON 形式で返しています。

- 異常系の処理
このエンドポイントでの異常系は 401, 500 となっています。
401 は authorization にてレスポンスが返される認識で、
500 も別 issue で扱う予定となっています。
そのため、このエンドポイントのテストでは正常系のみテストを記述しています。

## レビュワーに見て欲しいところ

モデル内の記述、FactoryBot の定義、各テストファイルなど、
全体的に処理・文法等についてつっこみどころがあればご指摘いただきたいです。
よろしくお願いいたします！