### PR TITLE
ローカル環境の rails のコンテナ内で rails dbconsole を使えなかったため解消

### DIFF
--- a/docker/Dockerfile.dev.api
+++ b/docker/Dockerfile.dev.api
@@ -3,7 +3,8 @@ FROM ruby:3.2.0-buster
 
 # 開発環境では `rails credentials:edit` で使うテキストエディタが必要になるので vim をインストール
 # ローカルに rails をインストールしてる場合は好きなエディタを用いてもよい
-RUN apt-get update && apt-get install -y vim
+RUN apt-get update && apt-get install -y vim \
+    default-mysql-client
 ENV EDITOR="vim"
 
 RUN gem install bundler && \

--- a/docker/Dockerfile.dev.api
+++ b/docker/Dockerfile.dev.api
@@ -1,10 +1,13 @@
 # slim だと rails の依存エラー
 FROM ruby:3.2.0-buster
 
-# 開発環境では `rails credentials:edit` で使うテキストエディタが必要になるので vim をインストール
-# ローカルに rails をインストールしてる場合は好きなエディタを用いてもよい
-RUN apt-get update && apt-get install -y vim \
+RUN apt-get update && apt-get install -y \
+    # 開発環境では `rails credentials:edit` で使うテキストエディタが必要になるので vim をインストール
+    # ローカルに rails をインストールしてる場合は好きなエディタを用いてもよい
+    vim \
+    # `rails dbconsole` を使えるように mysql-cli をインストール
     default-mysql-client
+
 ENV EDITOR="vim"
 
 RUN gem install bundler && \


### PR DESCRIPTION
## 背景

ローカル環境で rails のための用意しているコンテナにて `rails dbconsole` を実行したところ、
コンテナ内に mysql-client がないよと怒られてしまいました。

現状でも db の方のコンテナにアタッチすれば DB の内容を確認することはできるのですが、
コンテナの接続を切り替えをするのが手間に感じました。

## この PR で起こること

rails 用のコンテナに mysql-cli を入れてみたので `rails dbconsole` が使えるようになります。

## レビュワーに依頼したいこと

この変更についてなにか懸念や問題点などがないか、ご確認をお願いしたいと思っています。
今の私の認識では特にデメリットはなく、rails 用コンテナ内でできることが増える、という認識です。

お手隙の際にご確認をお願いできますでしょうか？
よろしくお願いいたします。
(小さな PR なので、問題なければマージをお願いできればと思います)