### PR TITLE
add: エンドポイント定義書にある、全てのエンドポイントを仮定義

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,22 @@
+class TasksController < ApplicationController
+  skip_before_action :authenticate
+  def create
+    render json: {}, status: :ok
+  end
+
+  def recording
+    render json: {}, status: :ok
+  end
+
+  def pending
+    render json: {}, status: :ok
+  end
+
+  def stop
+    render json: {}, status: :ok
+  end
+
+  def complete
+    render json: {}, status: :ok
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,11 @@ Rails.application.routes.draw do
       patch 'stop'
       patch 'complete'
     end
-  end
-  get 'tasks/recording', 'tasks#recording'
-  get 'tasks/pending', 'tasks#pending'
+     collection do
+       get 'recording'
+       get 'pending'
+     end
+   end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,14 @@
 Rails.application.routes.draw do
   resources :accounts, only: [:index, :create]
   resources :task_groups, only: [:index], path: "task-groups"
+  resources :tasks, only: [:create] do
+    member do
+      patch 'stop'
+      patch 'complete'
+    end
+  end
+  get 'tasks/recording', 'tasks#recording'
+  get 'tasks/pending', 'tasks#pending'
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+# 仮りで全てのエンドポイントを定義し、正常に応答することだけ確認
+RSpec.describe 'Tasks' do
+  describe 'POST /tasks' do
+    before do
+      post '/tasks'
+    end
+
+    it 'returns 200 as dummy.' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'returns empty json' do
+      expect(response.body).to eq('{}')
+    end
+  end
+
+  describe 'PATCH /tasks/:id/stop' do
+    before do
+      patch '/tasks/1/stop'
+    end
+
+    it 'returns 200 as dummy.' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'returns empty json' do
+      expect(response.body).to eq('{}')
+    end
+  end
+
+  describe 'PATCH /tasks/:id/complete' do
+    before do
+      patch '/tasks/2/complete'
+    end
+
+    it 'returns 200 as dummy.' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'returns empty json' do
+      expect(response.body).to eq('{}')
+    end
+  end
+
+  describe 'GET /tasks/recording' do
+    before do
+      get '/tasks/recording'
+    end
+
+    it 'returns 200 as dummy.' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'returns empty json' do
+      expect(response.body).to eq('{}')
+    end
+  end
+
+  describe 'GET /tasks/pending' do
+    before do
+      get '/tasks/pending'
+    end
+
+    it 'returns 200 as dummy.' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'returns empty json' do
+      expect(response.body).to eq('{}')
+    end
+  end
+end


### PR DESCRIPTION
close #57 

## やったこと

https://timmew.commew.net/docs/api#/operations/getTasksPending
こちらで定義のあるエンドポイントのうち、

- tasks

に含まれる5つのエンドポイントを仮定義し、200 で空の JSON を返すように記述しました。

## その他伝えたいこと

- accounts
- task-groups

についてはすでに準備済みという認識です。
commit した内容以外に、もし他にこの PR 内で追加した方がよい
エンドポイントなどがあれば教えていただければと思います。

ご確認をよろしくお願いいたします！