### PR TITLE
TaskモデルからTaskTimeUnitへのリレーションシップの名前を複数形に

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,4 @@
 class Task < ApplicationRecord
   belongs_to :task_category
-  has_many :task_time_unit, dependent: :destroy
+  has_many :task_time_units, dependent: :destroy
 end


### PR DESCRIPTION
has_manyなので複数形の方が適切。

Closes #61 

@HaruyaFujimoto 問題なさそうであればそのままマージまでお願いします。