### PR TITLE
modify: task と task_time_unit の factory を役に立つものに調整

### DIFF
--- a/spec/factories/task_time_units.rb
+++ b/spec/factories/task_time_units.rb
@@ -1,6 +1,9 @@
+# 呼ぶときは FactoryBot.build :task_time_unit とすること (インスタンス生成だけ)
+# Task との関連なしに DB 保存しようとするとエラーが発生する
+# task のコンポジット
 FactoryBot.define do
   factory :task_time_unit do
-    start_at { TimeWithZone.now }
-    task { association :task }
+    start_at { Time.zone.now }
+    end_at { nil }
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :task do
     completed { false }
     task_category { association :task_category }
+    task_time_units { [FactoryBot.build(:task_time_unit)] }
   end
 end


### PR DESCRIPTION
task 関連のエンドポイントを実装していたら、現状のこの2つの factory があまり役に立つものではなかったので、
先にこちらだけ反映したいです。
林さんの作業にも影響すると思うためです。
他作業中に気がついたところだったので issue なしですいません。

account と open_id_provider の関係と、task と task_time_unit の関係は
結構同じ様子で、account のテストに open_id_provider は必須だし
task のテストやメインのロジックに task_time_unit は必須だと思っています。
(クラス図などで言うところのコンポジットの関係のような感じに思っています)

そのため、task_time_unit の factory については、task の factory から呼ばれる想定で書いています。

おかしなところなどなければマージをお願いできればと思います。

ご確認をよろしくお願いいたします！