### PR TITLE
feat: タスクの記録を終了するエンドポイントを実装、自動テスト実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -17,6 +17,50 @@ class TasksController < ApplicationController
   end
 
   def complete
-    render json: {}, status: :ok
+    task = Task.where(id: params[:id]).first
+    return render_not_founded if task.nil?
+    return render_already_completed if task.completed
+
+    task.make_completed
+    render_make_task_completed task
+  end
+
+  private
+
+  def render_make_task_completed(task)
+    task_category_id, task_group_id = Task.joins(:task_category).where(id: task.id)
+                                          .pick('task_categories.id', 'task_categories.task_group_id')
+    render json: {
+      id: task.id,
+      status: task.status,
+      startAt: task.task_time_units.first.start_at.rfc3339,
+      endAt: task.task_time_units.last.end_at.rfc3339,
+      taskGroupId: task_group_id,
+      taskCategoryId: task_category_id
+    }, status: :ok
+  end
+
+  def render_not_founded
+    render json: {
+      type: 'BAD REQUEST',
+      title: 'Bad Request',
+      invalidParams: [
+        {
+          id: 'Tasks dosen\'t have the id.'
+        }
+      ]
+    }, status: :bad_request
+  end
+
+  def render_already_completed
+    render json: {
+      type: 'BAD REQUEST',
+      title: 'Bad Request',
+      invalidParams: [
+        {
+          id: 'The task is already in completed status.'
+        }
+      ]
+    }, status: :bad_request
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,20 @@
 class Task < ApplicationRecord
   belongs_to :task_category
   has_many :task_time_units, dependent: :destroy
+
+  def status
+    return :completed if completed
+    return :recording if task_time_units.last.end_at.nil?
+
+    :pending
+  end
+
+  def make_completed
+    latest_task_time_unit = task_time_units.last
+    latest_task_time_unit.end_at = Time.zone.now if latest_task_time_unit.end_at.nil?
+    transaction do
+      latest_task_time_unit.save if latest_task_time_unit.has_changes_to_save?
+      update(completed: true)
+    end
+  end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # 仮りで全てのエンドポイントを定義し、正常に応答することだけ確認
 RSpec.describe 'Tasks' do
-  describe 'POST /tasks' do
+  describe 'POST /tasks', skip: 'not implemented yet' do
     before do
       post '/tasks'
     end
@@ -16,7 +16,7 @@ RSpec.describe 'Tasks' do
     end
   end
 
-  describe 'PATCH /tasks/:id/stop' do
+  describe 'PATCH /tasks/:id/stop', skip: 'not implemented yet' do
     before do
       patch '/tasks/1/stop'
     end
@@ -31,20 +31,84 @@ RSpec.describe 'Tasks' do
   end
 
   describe 'PATCH /tasks/:id/complete' do
+    let(:task_group) { create(:task_group) }
+    let(:task_category) { create(:task_category, task_group:, name: 'その他') }
+
     before do
-      patch '/tasks/2/complete'
+      patch "/tasks/#{task.id}/complete"
     end
 
-    it 'returns 200 as dummy.' do
-      expect(response).to have_http_status(200)
+    context 'when task is recording, and task has some task_time_units' do
+      let(:task_time_units) do
+        [
+          build(:task_time_unit,
+                start_at: '2023-09-09T00:00:00Z',
+                end_at: '2023-09-09T01:00:00Z'),
+          build(:task_time_unit,
+                start_at: '2023-09-09T02:00:00Z',
+                end_at: '2023-09-09T03:00:00Z')
+        ]
+      end
+      let(:task) { create(:task, task_category:, task_time_units:) }
+
+      it 'returns 200.' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns expected json.' do
+        result = JSON.parse(response.body)
+        expected_keys = %w[
+          id
+          status
+          startAt
+          endAt
+          taskGroupId
+          taskCategoryId
+        ]
+        expect(result.keys).to eq(expected_keys)
+      end
+
+      it 'returns "startAt" param, set value from first task_time_unit.' do
+        result = JSON.parse(response.body)['startAt']
+        expected = task_time_units.first.start_at.rfc3339
+        expect(result).to eq(expected)
+      end
+
+      it 'returns "endAt" param, set value from last task_time_unit.' do
+        result = JSON.parse(response.body)['endAt']
+        expected = task_time_units.last.end_at.rfc3339
+        expect(result).to eq(expected)
+      end
     end
 
-    it 'returns empty json' do
-      expect(response.body).to eq('{}')
+    context 'when task is pending' do
+      let(:task_time_units) { [build(:task_time_unit, start_at: '2023-09-09', end_at: '2023-09-10')] }
+      let(:task) { create(:task, task_category:, task_time_units:) }
+
+      it 'returns 200.' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when task is completed' do
+      let(:task_time_units) { [build(:task_time_unit, start_at: '2023-09-09', end_at: '2023-09-10')] }
+      let(:task) { create(:task, task_category:, task_time_units:, completed: true) }
+
+      it 'returns 400.' do
+        expect(response).to have_http_status(400)
+      end
+    end
+
+    context 'when id in path parameter is not exists' do
+      let(:task) { build(:task, id: 0) }
+
+      it 'returns 400.' do
+        expect(response).to have_http_status(400)
+      end
     end
   end
 
-  describe 'GET /tasks/recording' do
+  describe 'GET /tasks/recording', skip: 'not implemented yet' do
     before do
       get '/tasks/recording'
     end
@@ -58,7 +122,7 @@ RSpec.describe 'Tasks' do
     end
   end
 
-  describe 'GET /tasks/pending' do
+  describe 'GET /tasks/pending', skip: 'not implemented yet' do
     before do
       get '/tasks/pending'
     end


### PR DESCRIPTION
close #43

他のエンドポイントとの共有部分もあると思うので、とりあえず draft で変更内容について共有します。

## この PR の中で行っていること

このエンドポイントで使用するために、Task モデルに

- status
- make_completed

というメソッドを定義しています。

それらを利用して、`PATCH: /tasks/{taskId}/complete` のエンドポイントのための実装を行いました。

## 用意したテストケース

- 成功パターン
  - 複数の task_time_units を持っていて、recording の状態にあたる task へのリクエスト
  - 一つだけ task_time_units を持っていて、pending の状態にあたる task へのリクエスト
- 失敗パターン
  - すでに completed = true の task へのリクエスト
  - パスパラメータの id が存在しないリクエスト

## 見てほしい、相談したいところ

Task#status は私が担当することになっている、タスクを停止・中止するエンドポイントでは
実装の中で task.status で見れたら楽でいいなと思って作りました。

特定の状態のタスク一覧取得の方では、おそらくこのようなインスタンス単位でのステータス確認は
行わないと思いますので、
これを呼ぶのは前述した「タスクを停止・中止するエンドポイント」だけになるかなと思っています。

この辺の何を伝えたいかがまとめられていないので、まずは draft で PR を立てておく、という気持ちです。