### PR TITLE
タスクの計測時間に小数点以下が含まれる場合は切り捨てるように

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -26,7 +26,7 @@ class Task < ApplicationRecord
   def duration
     task_time_units.sum do |unit|
       unit.end_at.nil? ? 0 : unit.end_at - unit.start_at
-    end
+    end.truncate
   end
 
   def make_pending(end_at = nil)

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -80,6 +80,17 @@ RSpec.describe Task do
         expect(task.duration).to eq(expected)
       end
     end
+
+    context 'when end_at has millisecond precision' do
+      let(:task) do
+        task_time_units = [build(:task_time_unit, start_at: '2023-10-12 01:23:45', end_at: '2023-10-12 02:34:56.789')]
+        create(:task, task_time_units:)
+      end
+
+      it 'returns seconds without milliseconds' do
+        expect(task.duration).to eq (1 * 3600) + (11 * 60) + 11
+      end
+    end
   end
 
   describe '#make_pending' do


### PR DESCRIPTION
Closes #69

単純に計算結果を`.truncate`で切り捨てするようにしました。`.floor`は個人的に好きじゃないので`.truncate`です。実際には負の値にはならないはずなので関係ないですが。