### PR TITLE
タスクを停止・再開・終了するときに自分のタスクでなくても処理できていた

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ AllCops:
 RSpec/ExampleLength:
   Max: 15
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 6
+
 # シンボル(＝ステータスメッセージ)はここで自動生成されていて、変更されうるので数
 # 値(＝ステータスコード)を直に使う。
 # https://github.com/rack/rack/blob/main/lib/rack/utils.rb#L481-L484

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -53,25 +53,13 @@ class TasksController < ApplicationController
   end
 
   def recording
-    task_ids = Task
-               .joins(:task_time_units)
-               .joins(task_category: :task_group)
-               .merge(TaskTimeUnit.where(end_at: nil))
-               .merge(TaskGroup.where(account_id: @account))
-               .pluck(:id)
+    task_ids = Task.recording_tasks_for(@account).pluck(:id)
 
     render_tasks Task.preload(:task_time_units).where(id: task_ids)
   end
 
   def pending
-    task_ids = Task
-               .joins(:task_time_units)
-               .joins(task_category: :task_group)
-               .where(completed: false)
-               .merge(TaskGroup.where(account_id: @account))
-               .group('tasks.id')
-               .having('COUNT(*) = SUM(IF(task_time_units.end_at IS NOT NULL, 1, 0))')
-               .pluck(:id)
+    task_ids = Task.pending_tasks_for(@account).pluck(:id)
 
     render_tasks Task.preload(:task_time_units).where(id: task_ids)
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -13,6 +13,8 @@ class TasksController < ApplicationController
   def stop
     task = Task.find(params[:id])
 
+    return render_forbidden 'タスクを停止する権限がありません' if task.account.id != @account.id
+
     begin
       task.make_pending
     rescue TaskStatusError => e
@@ -25,6 +27,8 @@ class TasksController < ApplicationController
   def start
     task = Task.find(params[:id])
 
+    return render_forbidden 'タスクを再開する権限がありません' if task.account.id != @account.id
+
     begin
       task.make_recording
     rescue TaskStatusError => e
@@ -36,6 +40,8 @@ class TasksController < ApplicationController
 
   def complete
     task = Task.find(params[:id])
+
+    return render_forbidden 'タスクを終了する権限がありません' if task.account.id != @account.id
 
     begin
       task.make_completed
@@ -113,5 +119,13 @@ class TasksController < ApplicationController
       title: 'Invalid status transition.',
       detail: error.message
     }, status: :bad_request
+  end
+
+  def render_forbidden(error_message)
+    render json: {
+      type: 'UNAUTHORIZED',
+      title: 'Account is not authorized.',
+      detail: error_message
+    }, status: :forbidden
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -16,6 +16,10 @@ class Task < ApplicationRecord
   validates :task_time_units, presence: true
   validate :verify_account, on: :create
 
+  def account
+    task_category.task_group.account
+  end
+
   def verify_account
     # task_categoryがない場合はそちらでエラーが出るので、こちらでは無視してOK.
     return unless task_category

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -88,5 +88,23 @@ class Task < ApplicationRecord
         task.save
       end
     end
+
+    def recording_tasks_for(account)
+      Task
+        .joins(:task_time_units)
+        .joins(task_category: :task_group)
+        .merge(TaskTimeUnit.where(end_at: nil))
+        .merge(TaskGroup.where(account_id: account))
+    end
+
+    def pending_tasks_for(account)
+      Task
+        .joins(:task_time_units)
+        .joins(task_category: :task_group)
+        .where(completed: false)
+        .merge(TaskGroup.where(account_id: account))
+        .group('tasks.id')
+        .having('COUNT(*) = SUM(IF(task_time_units.end_at IS NOT NULL, 1, 0))')
+    end
   end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -116,8 +116,6 @@ RSpec.describe 'Tasks' do
     end
   end
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
-  # letが多いが、いずれも必要なため
   describe 'PATCH /tasks/:id/stop' do
     let(:task_category) { create(:task_category) }
 
@@ -231,9 +229,7 @@ RSpec.describe 'Tasks' do
       end
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe 'PATCH /tasks/:id/start' do
     let(:task_category) { create(:task_category) }
 
@@ -339,7 +335,6 @@ RSpec.describe 'Tasks' do
       end
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
 
   describe 'PATCH /tasks/:id/complete' do
     let(:task_group) { create(:task_group) }


### PR DESCRIPTION
Closes #77

`/account/1/task/2`のようなパスならアカウントからタスクを引く形でもいいかなと思いましたが、今回は`/tasks/2`だけのようなパスなこともあり、今まで通り`Task.find`ベースでタスクを取得した後で、アカウントの整合をチェックする形にしました。

修正後にRuboCopの指摘箇所の修正コミットがあったりするので、コミット単位で見ていただいた方がわかりやすいかと思います。