### PR TITLE
staging 環境への自動デプロイのためのファイルを追加

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,66 @@
+name: Staging Deployment
+
+## staging
+on:
+  push:
+    branches:
+      - staging
+
+env:
+  PROJECT_ID: ${{ secrets.STG_PROJECT_ID }}
+  REGION: ${{ secrets.STG_REGION }}
+  IMAGE_URL: ${{ secrets.STG_IMAGE_URL }}:${{ github.sha }}
+  SERVICE_NAME: ${{ secrets.STG_SERVICE_NAME }}
+  WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.STG_WORKLOAD_IDENTITY_PROVIDER }}
+  SERVICE_ACCOUNT_EMAIL: ${{ secrets.STG_SERVICE_ACCOUNT_EMAIL }}
+jobs:
+  build-and-push-container-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v3'
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT_EMAIL }}
+          access_token_lifetime: '900s'
+          # image ビルドにかかる時間を考慮して15分に設定
+          # access_token は docker push が実行されるまで
+          # 有効期限が必要かと思い、そのように設定
+
+      ## Artifact Registry, using docker
+      - uses: 'docker/login-action@v1'
+        name: 'Docker login using OAuth2'
+        with:
+          registry: '${{ env.REGION }}-docker.pkg.dev'
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
+
+      - name: 'Build Docker Image'
+        run: |-
+          docker build -t local/image --build-arg ENV="production" ./
+          docker tag local/image ${{ env.IMAGE_URL }}
+
+      - name: 'Push Docker Image'
+        run: docker push ${{ env.IMAGE_URL }}
+
+      ## Cloud Run
+      - name: 'Deploy to Cloud Run'
+        id: 'deploy'
+        uses: 'google-github-actions/deploy-cloudrun@v1'
+        with:
+          service: ${{ env.SERVICE_NAME }}
+          region: ${{ env.REGION }}
+          image: ${{ env.IMAGE_URL }}
+          project_id: ${{ env.PROJECT_ID }}
+
+      ## for reducing cost
+      - name: 'Remove Image from Artifact Registry'
+        run: gcloud artifacts docker images delete ${{ env.IMAGE_URL }} --quiet


### PR DESCRIPTION
close #11

## 作業内容

production 環境へのデプロイ用のファイルを複製し、github にて必要な secret の登録を行いました。

## PR が merge されたあとの想定

この変更を反映後、stg ブランチへ統合する PR を立てて merge 後にデプロイが成功するかを確認したいと思っています。
問題なく動作したら main ブランチへも PR を立てて、prodution 環境へのデプロイも動かしてみたいと思っています。
もしどちらかへのデプロイにて失敗するようなことがあれば、その旨の issue を立てて今回の作業は終了をしようと考えています。